### PR TITLE
uchiwa.json should not be readable by all users.

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -7,5 +7,6 @@
     dest=/etc/sensu/uchiwa.json
     owner=uchiwa
     group=uchiwa
+    mode=0640
   notify:
     - restart uchiwa


### PR DESCRIPTION
uchiwa.json may contain a password so it should not be readable by all system users.
