### PR TITLE
rename pass variable to passwd

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,16 +16,16 @@ Vagrant.configure('2') do |config|
     config.vm.define vm do |machine|
       machine.vm.hostname = "#{vm}-standalone"
       machine.vm.network :private_network, :ip => specs['ip']
-      machine.vm.network "forwarded_port", guest: 3000, host: specs['local_port'] 
+      machine.vm.network "forwarded_port", guest: 3000, host: specs['local_port']
       machine.vm.box = specs['box']
- 
+
       machine.vm.provision 'ansible' do |ansible|
         ansible.playbook = 'vagrant/site.yml'
         ansible.groups = {
           'debian' => ['debian-standalone'],
           'redhat' => ['redhat-standalone']
         }
-        ansible.limit = "#{vm}" 
+        ansible.limit = "#{vm}"
         ansible.sudo = true
         ansible.host_key_checking = false
       end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,7 +53,7 @@ sensu_default_endpoint:
 host: 0.0.0.0
 port: 3000
 user: ''
-pass: ''
+passwd: ''
 refresh: 5
 users: []
 auth: {}

--- a/tasks/repo/apt.yml
+++ b/tasks/repo/apt.yml
@@ -8,4 +8,4 @@
 - name: Add the official sensu repository
   apt_repository:
     repo='deb {{ sensu_apt_repo_url }} {{ sensu_apt_repo_distribution }} {{ sensu_apt_repo }}'
-    state=present 
+    state=present

--- a/tasks/repo/yum.yml
+++ b/tasks/repo/yum.yml
@@ -2,10 +2,10 @@
 
 - include: ../redhat/selinux.yml
   when: not ansible_selinux
- 
+
 - name: Add the official sensu repository
   copy:
-    src='../../files/{{ sensu_yum_repo }}.repo'
+    src='files/{{ sensu_yum_repo }}.repo'
     dest='/etc/yum.repos.d'
     owner=root
-    group=root 
+    group=root

--- a/tasks/repo/yum.yml
+++ b/tasks/repo/yum.yml
@@ -5,7 +5,7 @@
 
 - name: Add the official sensu repository
   copy:
-    src='../../files/{{ sensu_yum_repo }}.repo'
+    src='files/{{ sensu_yum_repo }}.repo'
     dest='/etc/yum.repos.d'
     owner=root
     group=root

--- a/templates/uchiwa.json.j2
+++ b/templates/uchiwa.json.j2
@@ -18,7 +18,7 @@
     "host": "{{ host }}",
     "port": {{ port }},
     "user": "{{ user }}",
-    "pass": "{{ pass }}",
+    "pass": "{{ passwd }}",
     "refresh": {{ refresh }}{{ ',' if users or auth else '' }}
 {% if users %}
     "users": [


### PR DESCRIPTION
When trying to define a variable "pass" at including role uchiwa:

```
---                                                                                                                                                                                                                 
- hosts: uchiwa*                                                                                                                                                                                                    
  vars:                                                                                                                                                                                                             
    user: "admin"                                                                                                                                                                                                   
    pass: "somepassword"                                                                                                                                                                                      
  roles:                                                                                                                                                                                                            
    - role: uchiwa   
```

```
ERROR! Invalid variable name in vars specified for Play: 'pass' is not a valid variable name

The error appears to have been in '/Users/wizard/projects/sensu/playbooks/uchiwa.yml': line 4, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  vars:
      user: "admin"
          ^ here
```
