### PR TITLE
Added OS release for yum

### DIFF
--- a/files/sensu.repo
+++ b/files/sensu.repo
@@ -1,5 +1,5 @@
 [sensu]
 name=sensu-main
-baseurl=http://repositories.sensuapp.org/yum/$basearch/
+baseurl=http://repositories.sensuapp.org/yum/$releasever/$basearch/
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
The current URL in the repo file is wrong and fails the install, this can be fixed by adding a yum variable for OS version

Tested on CentOS 7
Repo url:
http://repositories.sensuapp.org/yum/7/x86_64/
Source:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_yum_variables